### PR TITLE
k0sctl v0.13.2

### DIFF
--- a/Formula/k0sctl.rb
+++ b/Formula/k0sctl.rb
@@ -2,18 +2,12 @@ class K0sctl < Formula
   desc "Bootstrapping and management tool for k0s kubernetes clusters"
   homepage "https://github.com/k0sproject/k0sctl"
   url "https://github.com/k0sproject/k0sctl.git",
-      tag:      "v0.13.0",
-      revision: "9e46423832d65976141ca5e95a92eb07aef5d288"
+      tag:      "v0.13.2",
+      revision: "71160254031c64fb42d138e138e4d26f145575f0"
   license "Apache-2.0"
   head "https://github.com/k0sproject/k0sctl.git", branch: "main"
 
-  bottle do
-    root_url "https://github.com/k0sproject/homebrew-tap/releases/download/k0sctl-0.13.0"
-    sha256 cellar: :any_skip_relocation, big_sur:      "3b9d9128a902675452f90571495070c6c453ae9b4383afc9b47ec877e408a7bc"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "313ce3832a513ca5bdd22a6bb46903e9ddbef55775c24a41f6c9a7622ddef3ce"
-  end
-
-  depends_on "go@1.18" => :build
+  depends_on "go@1.19" => :build
 
   def install
     system "make", "k0sctl", "TAG_NAME=v#{version}"


### PR DESCRIPTION
Signed-off-by: Kimmo Lehto <klehto@mirantis.com>

K0sctl v0.13.2

New PR to replace #11  (and #10) which seem to have failed because the branch name is equal to the tag name it tries to create.
