### PR TITLE
Update tap workflows

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -23,10 +23,6 @@ jobs:
           key: ${{ runner.os }}-rubygems-${{ steps.set-up-homebrew.outputs.gems-hash }}
           restore-keys: ${{ runner.os }}-rubygems-
 
-      - name: Install Homebrew Bundler RubyGems
-        if: steps.cache.outputs.cache-hit != 'true'
-        run: brew install-bundler-gems
-
       - run: brew test-bot --only-cleanup-before
 
       - run: brew test-bot --only-setup


### PR DESCRIPTION
See if that helps with failing tests on PRs.

I don't know where the up to date workflows can be found from, the best way I've found is to do `brew tap-new foofoo/foo` and copy from there.
