### PR TITLE
Fix/standardize completion generation for k0sctl

### DIFF
--- a/Formula/k0sctl.rb
+++ b/Formula/k0sctl.rb
@@ -22,7 +22,6 @@ class K0sctl < Formula
 
     generate_completions_from_executable(
       bin/"k0sctl", "completion",
-      ["bash", "zsh", "fish"],
       shell_parameter_format: :arg
     )
   end


### PR DESCRIPTION
apparently the generate_completions_from_executable args were not quite correct
